### PR TITLE
Initial status/timing computations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.2.blockapis-SNAPSHOT</version>
+            <version>2.2.blockapis-SNAPSHOT</version> <!-- allows consuming the new APIs -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -60,7 +60,6 @@
             <version>2.0</version>
             <optional>true</optional>
         </dependency>
-        <!-- Needed if we go to v2.x pipeline -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
@@ -81,7 +80,14 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>${workflow.version}</version>
+            <version>1.15</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>1.15</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,12 @@
             <version>${workflow.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.pipeline-stage-view</groupId>
+            <artifactId>pipeline-rest-api</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- May be able to remove these due to core -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@
     </scm>
 
     <properties>
-        <jenkins.version>1.609.3</jenkins.version>
+        <jenkins.version>1.642.3</jenkins.version>
         <java.level>7</java.level>
-        <workflow.version>1.14</workflow.version>
+        <workflow.version>2.0</workflow.version>
         <jackson.version>2.4.0</jackson.version>
     </properties>
 
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>${workflow.version}</version>
+            <version>2.2.blockapis-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -61,11 +61,11 @@
             <optional>true</optional>
         </dependency>
         <!-- Needed if we go to v2.x pipeline -->
-        <!--<dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-stage-step</artifactId>
             <version>${workflow.version}</version>
-        </dependency> -->
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
@@ -82,7 +82,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <version>${workflow.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
@@ -1,0 +1,48 @@
+package org.jenkinsci.plugins.workflow.pipelinegraphanalysis;
+
+import hudson.model.Result;
+
+/**
+ * Statuses of a {@link org.jenkinsci.plugins.workflow.graphanalysis.FlowChunk} in increasing priority order
+ */
+public enum GenericStatus {
+    /**
+     * Can't be determined for whatever reason, possibly in an undefined or transitory state
+     */
+    UNKNOWN,
+
+    /**
+     * We resumed from checkpoint or {@link Result#NOT_BUILT} status
+     */
+    NOT_EXECUTED,
+
+    /**
+     * Success, ex {@link Result#SUCCESS}
+     */
+    SUCCESS,
+
+    /**
+     * Recoverable failures, such as noncritical tests, ex {@link Result#UNSTABLE}
+     */
+    UNSTABLE,
+
+    /**
+     * Still executing, waiting for a result
+     */
+    IN_PROGRESS,
+
+    /**
+     * Ran and explicitly failed, i.e. {@link Result#FAILURE}
+     */
+    FAILURE,
+
+    /**
+     * Aborted while running, no way to determine final outcome {@link Result#ABORTED}
+     */
+    ABORTED,
+
+    /**
+     * We are waiting for user input to continue (special case IN_PROGRESS
+     */
+    PAUSED_PENDING_INPUT
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/GenericStatus.java
@@ -12,27 +12,27 @@ public enum GenericStatus {
     UNKNOWN,
 
     /**
-     * We resumed from checkpoint or {@link Result#NOT_BUILT} status
+     * We resumed from checkpoint or {@link Result#NOT_BUILT} status - nothing ran in the chunk.
      */
     NOT_EXECUTED,
 
     /**
-     * Success, ex {@link Result#SUCCESS}
+     * Completed & successful, ex {@link Result#SUCCESS}
      */
     SUCCESS,
 
     /**
-     * Recoverable failures, such as noncritical tests, ex {@link Result#UNSTABLE}
+     * Completed with recoverable failures, such as noncritical tests, ex {@link Result#UNSTABLE}
      */
     UNSTABLE,
 
     /**
-     * Still executing, waiting for a result
+     * Not complete: still executing, waiting for a result
      */
     IN_PROGRESS,
 
     /**
-     * Ran and explicitly failed, i.e. {@link Result#FAILURE}
+     * Completed and explicitly failed, i.e. {@link Result#FAILURE}
      */
     FAILURE,
 
@@ -42,7 +42,7 @@ public enum GenericStatus {
     ABORTED,
 
     /**
-     * We are waiting for user input to continue (special case IN_PROGRESS
+     * Not complete: we are waiting for user input to continue (special case of IN_PROGRESS)
      */
     PAUSED_PENDING_INPUT
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -1,7 +1,12 @@
 package org.jenkinsci.plugins.workflow.pipelinegraphanalysis;
 
 import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.NotExecutedNodeAction;
+import org.jenkinsci.plugins.workflow.actions.TimingAction;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
@@ -9,26 +14,98 @@ import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
 
 /**
- * Provides common APIs for doing status and timing computations
+ * Provides common APIs for doing status and timing computations on flows
+ * Concepts: a chunk, which is a set of {@link FlowNode}s in the same exection with a first and last node.
+ * Chunks exist in a context
  * @author Sam Van Oort
  */
 public class StatusAndTiming {
 
+    private static final Logger LOGGER = Logger.getLogger(StatusAndTiming.class.getName());
+
+    // Sorted in increasing priority
     public enum GenericStatus {
+        UNKNOWN,
         NOT_EXECUTED,
-        ABORTED,
         SUCCESS,
-        IN_PROGRESS,
-        PAUSED_PENDING_INPUT,
-        FAILED,
         UNSTABLE,
-        CUSTOM // Not currently implemented, but allows us to support custom status annotations
+        IN_PROGRESS,
+        FAILED,
+        ABORTED,
+        PAUSED_PENDING_INPUT
     }
 
-    private static boolean isPendingInput(WorkflowRun run) {
+    public static class TimingInfo {
+        private long totalDurationMillis;
+        private long pauseDurationMillis;
+
+        public TimingInfo() {
+            this.totalDurationMillis = 0;
+            this.pauseDurationMillis = 0;
+        }
+
+        public TimingInfo(long totalDurationMillis, long pauseDurationMillis) {
+            this.totalDurationMillis = totalDurationMillis;
+            this.pauseDurationMillis = pauseDurationMillis;
+        }
+
+        public long getTotalDurationMillis() {
+            return totalDurationMillis;
+        }
+
+        public void setTotalDurationMillis(long totalDurationMillis) {
+            this.totalDurationMillis = totalDurationMillis;
+        }
+
+        public long getPauseDurationMillis() {
+            return pauseDurationMillis;
+        }
+
+        public void setPauseDurationMillis(long pauseDurationMillis) {
+            this.pauseDurationMillis = pauseDurationMillis;
+        }
+    }
+
+    /**
+     * Get the start time for node, or null if not present
+     * @param node Node to get time for
+     * @return Start time of node in millis, or null if no timing present
+     */
+    @CheckForNull
+    public static Long getStartTime(@Nonnull FlowNode node) {
+        TimingAction time = node.getAction(TimingAction.class);
+        return (time == null) ? null : time.getStartTime();
+    }
+
+    /**
+     * Check that all the flownodes belong to the same execution as run
+     * @param run Run that nodes must belong to
+     * @param nodes Nodes to match to run
+     * @throws IllegalArgumentException For the first flownode that doesn't belong to the FlowExectuon of run
+     */
+    public static void verifySameRun(@Nonnull WorkflowRun run, @CheckForNull FlowNode... nodes) throws IllegalArgumentException {
+        if (nodes == null || nodes.length == 0) {
+            return;
+        }
+        FlowExecution exec = run.getExecution();
+        int i =0;
+        for (FlowNode n : nodes) {
+            if (n!= null && n.getExecution() != exec) {
+                throw new IllegalArgumentException("FlowNode not part of the same execution found, at index "+i+" with ID "+n.getId());
+            }
+            i++;
+        }
+    }
+
+    public static boolean isPendingInput(WorkflowRun run) {
         // Logic borrowed from Pipeline Stage View plugin, RuneEx
         InputAction inputAction = run.getAction(InputAction.class);
         if (inputAction != null) {
@@ -43,6 +120,7 @@ public class StatusAndTiming {
     public static GenericStatus getChunkStatus(@Nonnull WorkflowRun run,
                                         @CheckForNull FlowNode before, @Nonnull FlowNode firstNode,
                                         @Nonnull FlowNode lastNode, @CheckForNull FlowNode after) {
+        verifySameRun(run, before, firstNode, lastNode, after);
         boolean isLastChunk = after == null && run.getExecution().isCurrentHead(lastNode);
         if (isLastChunk && run.isBuilding()) {
             if (run.isBuilding()) {
@@ -75,11 +153,129 @@ public class StatusAndTiming {
         }
     }
 
-    public static Object getChunkTiming(@Nonnull WorkflowRun run,
+    /**
+     * Compute timing for a chunk of nodes
+     * @param run WorkflowRun they all belong to
+     * @param pauseDuration Millis paused (collected beforehand)
+     * @param before Node before the chunk, if null assume this is the first piece of the flow and has nothing before
+     * @param firstNode First node in the chunk
+     * @param lastNode Last node in the chunk
+     * @param after Node after the chunk, if null we assume this chunk is at the end of the flow
+     * @return Best guess at timing, or null if we can't compute anything
+     */
+    @CheckForNull
+    public static TimingInfo computeChunkTiming(@Nonnull WorkflowRun run, long pauseDuration,
                                         @CheckForNull FlowNode before, @Nonnull FlowNode firstNode,
                                         @Nonnull FlowNode lastNode, @CheckForNull FlowNode after) {
-        // Pause timing
-        // Run time, if executed at all
-        return null;
+        verifySameRun(run, before, firstNode, lastNode, after);
+        long startTime = TimingAction.getStartTime(firstNode);
+        long endTime = (after != null) ? TimingAction.getStartTime(after) : System.currentTimeMillis();
+
+        if (!NotExecutedNodeAction.isExecuted(lastNode)) {
+            return new TimingInfo(0,0);  // Nothing ran
+        }  else if (before == null) {
+            startTime = run.getStartTimeInMillis();
+        } else if (after == null && run.getExecution().isComplete()) {
+            // Completed flow
+            endTime = TimingAction.getStartTime(lastNode);
+        }
+        //TODO log me if startTime is 0 or handle missing TimingAction
+
+        return new TimingInfo((endTime-startTime), Math.min(Math.abs(pauseDuration), (endTime-startTime)));
+    }
+
+    /**
+     * Computes the branch timings for a set of parallel branches
+     * @param run
+     * @param branchTimings Map of branch name : precomputed timing info
+     * @param parallelStart
+     * @param parallelEnd
+     * @return
+     */
+    public static TimingInfo computeTimingForParallel(@Nonnull WorkflowRun run,
+                                                     @Nonnull Map<String, TimingInfo> branchTimings,
+                                                     @Nonnull FlowNode parallelStart, @CheckForNull FlowNode parallelEnd) {
+        long overallDuration = 0;
+        long maxPause = 0;
+        boolean isIncomplete = parallelEnd == null;
+        for (TimingInfo t : branchTimings.values()) {
+            maxPause = Math.max(maxPause, t.getPauseDurationMillis());
+            if (isIncomplete) {
+                overallDuration = Math.max(overallDuration, t.getTotalDurationMillis());
+            }
+        }
+        if (!isIncomplete) {
+            overallDuration = TimingAction.getStartTime(parallelEnd) - TimingAction.getStartTime(parallelStart);
+        }
+        return new TimingInfo(overallDuration, maxPause);
+    }
+
+    public static Map<String, TimingInfo> computeParallelBranchTimings(@Nonnull WorkflowRun run,
+                                                                       @Nonnull List<BlockStartNode> branchStarts,
+                                                                       @Nonnull List<FlowNode> branchEnds,
+                                                                       @Nonnull long[] pauseDurations,
+                                                                       @Nonnull FlowNode parallelStart, @CheckForNull FlowNode parallelEnd) {
+
+        verifySameRun(run, branchStarts.toArray(new FlowNode[0]));
+        verifySameRun(run, branchEnds.toArray(new FlowNode[0]));
+        if (branchStarts.size() != branchEnds.size()) {
+            throw new IllegalArgumentException("Mismatched start and stop node counts: "+branchStarts.size()+","+branchEnds.size());
+        }
+        if (branchStarts.size() != pauseDurations.length) {
+            throw new IllegalArgumentException("Mismatched node count and pause duration array: "+branchStarts.size()+","+pauseDurations.length);
+        }
+        HashMap<String, TimingInfo> timings = new HashMap<String,TimingInfo>();
+        for (int i=0; i<branchEnds.size(); i++) {
+            BlockStartNode start = branchStarts.get(i);
+            FlowNode end = branchEnds.get(i);
+            if (end instanceof BlockEndNode && start != ((BlockEndNode)end).getStartNode()) {
+                throw new IllegalArgumentException("Mismatched parallel branch start/end nodes: "
+                        + start.getId()+','
+                        + end.getId());
+            }
+            LabelAction label = start.getAction(LabelAction.class);
+            assert label != null;
+            timings.put(label.getDisplayName(), computeChunkTiming(run, pauseDurations[i], parallelStart, start, end, parallelEnd));
+        }
+        return timings;
+    }
+
+    /**
+     * Compute status codes for a set of parallel branches
+     * @param run Run containing these nodes
+     * @param branchStarts The nodes starting off each parallel branch (BlockStartNode)
+     * @param branchEnds Last node in each parallel branch - currentHeads if currently executing and not a BlockEndNode if currently executing the parallels
+     * @param parallelStart Start node for  overall parallel block
+     * @param parallelEnd End node for the overall parallelBlock (null if not complete)
+     * @return
+     */
+    public static Map<String, GenericStatus> computeBranchStatuses(@Nonnull WorkflowRun run,
+                                                               @Nonnull List<BlockStartNode> branchStarts,
+                                                               @Nonnull List<FlowNode> branchEnds,
+                                                               @Nonnull FlowNode parallelStart, @CheckForNull FlowNode parallelEnd) {
+        verifySameRun(run, branchStarts.toArray(new FlowNode[0]));
+        verifySameRun(run, branchEnds.toArray(new FlowNode[0]));
+        if (branchStarts.size() != branchEnds.size()) {
+            throw new IllegalArgumentException("Mismatched start and stop node counts: "+branchStarts.size()+","+branchEnds.size());
+        }
+        HashMap<String, GenericStatus> statusMappings = new HashMap<String, GenericStatus>();
+        for (int i=0; i<branchEnds.size(); i++) {
+            BlockStartNode start = branchStarts.get(i);
+            FlowNode end = branchEnds.get(i);
+            if (end instanceof BlockEndNode && start != ((BlockEndNode)end).getStartNode()) {
+                throw new IllegalArgumentException("Mismatched parallel branch start/end nodes: "
+                        + start.getId()+','
+                        + end.getId());
+            }
+            LabelAction label = start.getAction(LabelAction.class);
+            assert label != null;
+            statusMappings.put(label.getDisplayName(), getChunkStatus(run, parallelStart, start, end, parallelEnd));
+        }
+        return statusMappings;
+    }
+
+    /** Combines the status results from a list of parallel branches to report a single overall status */
+    public static GenericStatus condenseStatus(@Nonnull Collection<GenericStatus> statuses) {
+        return Collections.max(statuses);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -1,0 +1,85 @@
+package org.jenkinsci.plugins.workflow.pipelinegraphanalysis;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.actions.NotExecutedNodeAction;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
+import org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * Provides common APIs for doing status and timing computations
+ * @author Sam Van Oort
+ */
+public class StatusAndTiming {
+
+    public enum GenericStatus {
+        NOT_EXECUTED,
+        ABORTED,
+        SUCCESS,
+        IN_PROGRESS,
+        PAUSED_PENDING_INPUT,
+        FAILED,
+        UNSTABLE,
+        CUSTOM // Not currently implemented, but allows us to support custom status annotations
+    }
+
+    private static boolean isPendingInput(WorkflowRun run) {
+        // Logic borrowed from Pipeline Stage View plugin, RuneEx
+        InputAction inputAction = run.getAction(InputAction.class);
+        if (inputAction != null) {
+            List<InputStepExecution> executions = inputAction.getExecutions();
+            if (executions != null && !executions.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static GenericStatus getChunkStatus(@Nonnull WorkflowRun run,
+                                        @CheckForNull FlowNode before, @Nonnull FlowNode firstNode,
+                                        @Nonnull FlowNode lastNode, @CheckForNull FlowNode after) {
+        boolean isLastChunk = after == null && run.getExecution().isCurrentHead(lastNode);
+        if (isLastChunk && run.isBuilding()) {
+            if (run.isBuilding()) {
+                return (isPendingInput(run)) ? GenericStatus.PAUSED_PENDING_INPUT : GenericStatus.IN_PROGRESS;
+            } else {
+                // Final chunk on completed build
+                Result r = run.getResult();
+                if (r == Result.NOT_BUILT) {
+                    return GenericStatus.NOT_EXECUTED;
+                } else if (r == Result.ABORTED) {
+                    return GenericStatus.ABORTED;
+                } else if (r == Result.FAILURE ) {
+                    return GenericStatus.FAILED;
+                } else if (r == Result.UNSTABLE ) {
+                    return GenericStatus.UNSTABLE;
+                } else if (r == Result.SUCCESS) {
+                    return GenericStatus.SUCCESS;
+                } else {
+                    return GenericStatus.FAILED;
+                }
+            }
+        }
+
+        // Previous chunk before end. If flow continued beyond this, it didn't fail.
+        // TODO check that previous assertion... what about blocks where the lastNode doesn't include BlockEndNode?
+        if (!NotExecutedNodeAction.isExecuted(lastNode)) {
+            return GenericStatus.NOT_EXECUTED;
+        } else {
+            return (run.getResult() == Result.UNSTABLE) ? GenericStatus.UNSTABLE : GenericStatus.SUCCESS;
+        }
+    }
+
+    public static Object getChunkTiming(@Nonnull WorkflowRun run,
+                                        @CheckForNull FlowNode before, @Nonnull FlowNode firstNode,
+                                        @Nonnull FlowNode lastNode, @CheckForNull FlowNode after) {
+        // Pause timing
+        // Run time, if executed at all
+        return null;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTiming.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins.workflow.pipelinegraphanalysis;
 
 import hudson.model.Result;
 import org.jenkinsci.plugins.workflow.actions.ErrorAction;
-import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.NotExecutedNodeAction;
 import org.jenkinsci.plugins.workflow.actions.ThreadNameAction;
 import org.jenkinsci.plugins.workflow.actions.TimingAction;
@@ -195,10 +194,8 @@ public class StatusAndTiming {
                     return GenericStatus.FAILURE;
                 } else if (r == Result.UNSTABLE ) {
                     return GenericStatus.UNSTABLE;
-                } else if (r == Result.SUCCESS) {
-                    return GenericStatus.SUCCESS;
                 } else {
-                    return GenericStatus.FAILURE;
+                    return GenericStatus.SUCCESS;
                 }
             }
         }
@@ -217,7 +214,7 @@ public class StatusAndTiming {
      * Compute timing for a chunk of nodes
      * TODO create version taking single object
      * @param run WorkflowRun they all belong to
-     * @param pauseDuration Millis paused (collected beforehand)
+     * @param internalPauseDuration Millis paused in the chunk (including the ends)
      * @param before Node before the chunk, if null assume this is the first piece of the flow and has nothing before
      * @param firstNode First node in the chunk
      * @param lastNode Last node in the chunk
@@ -225,7 +222,7 @@ public class StatusAndTiming {
      * @return Best guess at timing, or null if we can't compute anything
      */
     @CheckForNull
-    public static TimingInfo computeChunkTiming(@Nonnull WorkflowRun run, long pauseDuration,
+    public static TimingInfo computeChunkTiming(@Nonnull WorkflowRun run, long internalPauseDuration,
                                         @CheckForNull FlowNode before, @Nonnull FlowNode firstNode,
                                         @Nonnull FlowNode lastNode, @CheckForNull FlowNode after) {
         FlowExecution exec = run.getExecution();
@@ -247,7 +244,7 @@ public class StatusAndTiming {
         }
         //TODO log me if startTime is 0 or handle missing TimingAction
 
-        return new TimingInfo((endTime-startTime), Math.min(Math.abs(pauseDuration), (endTime-startTime)));
+        return new TimingInfo((endTime-startTime), Math.min(Math.abs(internalPauseDuration), (endTime-startTime)));
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/TimingInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/TimingInfo.java
@@ -4,11 +4,6 @@ public class TimingInfo {
     private long totalDurationMillis;
     private long pauseDurationMillis;
 
-    public TimingInfo() {
-        this.totalDurationMillis = 0;
-        this.pauseDurationMillis = 0;
-    }
-
     public TimingInfo(long totalDurationMillis, long pauseDurationMillis) {
         this.totalDurationMillis = totalDurationMillis;
         this.pauseDurationMillis = pauseDurationMillis;
@@ -28,22 +23,5 @@ public class TimingInfo {
 
     public void setPauseDurationMillis(long pauseDurationMillis) {
         this.pauseDurationMillis = pauseDurationMillis;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o == null || !(o instanceof TimingInfo)) {
-            return false;
-        } else if (this == o) {
-            return true;
-        }
-        TimingInfo ti = (TimingInfo) o;
-        return this.pauseDurationMillis == ti.pauseDurationMillis && this.totalDurationMillis == ti.totalDurationMillis;
-    }
-
-    @Override
-    public int hashCode() {
-        long mixed = (~pauseDurationMillis) ^ totalDurationMillis;  // Bitwise invert because both are often equal
-        return (int) (mixed ^ (mixed >>> 32));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/TimingInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/TimingInfo.java
@@ -1,0 +1,49 @@
+package org.jenkinsci.plugins.workflow.pipelinegraphanalysis;
+
+public class TimingInfo {
+    private long totalDurationMillis;
+    private long pauseDurationMillis;
+
+    public TimingInfo() {
+        this.totalDurationMillis = 0;
+        this.pauseDurationMillis = 0;
+    }
+
+    public TimingInfo(long totalDurationMillis, long pauseDurationMillis) {
+        this.totalDurationMillis = totalDurationMillis;
+        this.pauseDurationMillis = pauseDurationMillis;
+    }
+
+    public long getTotalDurationMillis() {
+        return totalDurationMillis;
+    }
+
+    public void setTotalDurationMillis(long totalDurationMillis) {
+        this.totalDurationMillis = totalDurationMillis;
+    }
+
+    public long getPauseDurationMillis() {
+        return pauseDurationMillis;
+    }
+
+    public void setPauseDurationMillis(long pauseDurationMillis) {
+        this.pauseDurationMillis = pauseDurationMillis;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || !(o instanceof TimingInfo)) {
+            return false;
+        } else if (this == o) {
+            return true;
+        }
+        TimingInfo ti = (TimingInfo) o;
+        return this.pauseDurationMillis == ti.pauseDurationMillis && this.totalDurationMillis == ti.totalDurationMillis;
+    }
+
+    @Override
+    public int hashCode() {
+        long mixed = (~pauseDurationMillis) ^ totalDurationMillis;  // Bitwise invert because both are often equal
+        return (int) (mixed ^ (mixed >>> 32));
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/TimingInfo.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/TimingInfo.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.workflow.pipelinegraphanalysis;
 
+/** Container object for timing info about piece of a flow */
 public class TimingInfo {
     private long totalDurationMillis;
     private long pauseDurationMillis;

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -108,7 +108,7 @@ public class StatusAndTimingTest {
 
         // First non-start node to final end node
         status = StatusAndTiming.computeChunkStatus(run, n[0], n[1], n[5], null);
-        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILED, status);
+        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, status);
 
         // Whole flow except for end... since no errors here, failure must be at end!
         status = StatusAndTiming.computeChunkStatus(run, n[0], n[1], n[4], n[5]);

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -1,6 +1,8 @@
 package org.jenkinsci.plugins.workflow.pipelinegraphanalysis;
 
 import com.cloudbees.workflow.flownode.FlowNodeUtil;
+import com.google.common.collect.Maps;
+import com.sun.tools.javac.comp.Flow;
 import hudson.model.Action;
 import hudson.model.Result;
 import hudson.model.queue.QueueTaskFuture;
@@ -10,6 +12,7 @@ import org.jenkinsci.plugins.workflow.actions.TimingAction;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
+import org.jenkinsci.plugins.workflow.graph.BlockStartNode;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -20,7 +23,11 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by svanoort on 7/19/16.
@@ -36,12 +43,20 @@ public class StatusAndTimingTest {
         return IOUtils.toString(strm, "utf8");
     }
 
+    // Helper
     FlowNode[] getNodes(FlowExecution exec, int[] ids) throws IOException {
         FlowNode[] output = new FlowNode[ids.length];
         for (int i=0; i < ids.length; i++) {
             output[i] = exec.getNode(Integer.toString(ids[i]));
         }
         return output;
+    }
+
+    // Helper
+    public long doTiming(FlowExecution exec, int firstNodeId, int nodeAfterEndId) throws  IOException {
+        long startTime = TimingAction.getStartTime(exec.getNode(Integer.toString(firstNodeId)));
+        long endTime = TimingAction.getStartTime(exec.getNode(Integer.toString(nodeAfterEndId)));
+        return endTime-startTime;
     }
 
     @Test
@@ -124,12 +139,148 @@ public class StatusAndTimingTest {
                 "stage 'first' \n" +
                 "sleep 1 \n" +
                 "error('fails') \n"));
+        /**  Node dump follows, format:
+        [ID]{parent,ids} flowClassName displayName [st=startId if a block node]
+        Action format:
+        - actionClassName actionDisplayName
+                ------------------------------------------------------------------------------------------
+        [2]{}FlowStartNode Start of Pipeline
+        [3]{2}StepAtomNode Sleep
+        [4]{3}StepAtomNode first
+             -LogActionImpl Console Output
+             -LabelAction first
+             -StageActionImpl null
+        [5]{4}StepAtomNode Sleep
+        [6]{5}StepAtomNode Error signal
+             -ErrorAction fails
+             -ErrorAction fails
+        [7]{6}FlowEndNode End of Pipeline  [st=2]
+             -ErrorAction fails
+        */
         QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
-        j.assertBuildStatus(Result.FAILURE, build.get());
         WorkflowRun run = build.get();
-        long startTime = run.getStartTimeInMillis();
         FlowExecution exec = run.getExecution();
-        printNodes(exec, startTime, true, true);
+        j.assertBuildStatus(Result.FAILURE, run);
+
+        // Whole flow
+        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
+                run, null, exec.getNode("2"), exec.getNode("7"), null));
+
+        // Start through to failure point
+        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
+                run, null, exec.getNode("2"), exec.getNode("6"), exec.getNode("7")));
+
+        // All but first/last node
+        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
+                run, exec.getNode("2"), exec.getNode("3"), exec.getNode("6"), exec.getNode("7")));
+
+        // Before failure node
+        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, StatusAndTiming.computeChunkStatus(
+                run, exec.getNode("2"), exec.getNode("3"), exec.getNode("5"), exec.getNode("6")));
+    }
+
+    @Test
+    public void testBasicParallelFail() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "Fails");
+        job.setDefinition(new CpsFlowDefinition("" +
+                "stage 'primero'\n" +
+                "def branches = ['failFast': false]\n" +
+                "branches['success'] = {sleep 1; echo 'succeed'}\n" +
+                "branches['fail'] = {error('autofail');}\n" +
+                "parallel branches"));
+
+        /**
+         * Node dump from a run follows, format:
+         [ID]{parent,ids}(millisSinceStartOfRun) flowClassName displayName [st=startId if a block node]
+         Action format: (key actions only)
+         - actionClassName actionDisplayName
+         ------------------------------------------------------------------------------------------
+         [2]{}(N/A)FlowStartNode Start of Pipeline
+         [3]{2}StepAtomNode primero
+         -LabelAction primero,
+         -StageActionImpl null
+         [4]{3}(924)StepStartNode Execute in parallel : Start
+         [6]{4}(926)StepStartNode Branch: success
+         -ParallelLabelAction Branch: success
+         [7]{4}(928)StepStartNode Branch: fail
+         -ParallelLabelAction Branch: fail
+         [8]{6}(930)StepAtomNode Sleep
+         [9]{7}(932)StepAtomNode Error signal
+         -ErrorAction autofail
+         [10]{9}(938)StepEndNode Execute in parallel : Body : End  [st=7]
+         -ErrorAction autofail
+         [11]{8}(1827)StepAtomNode Print Message
+         [12]{11}(1829)StepEndNode Execute in parallel : Body : End  [st=6]
+         [13]{12,10}(1845)StepEndNode Execute in parallel : End  [st=4]
+         -ErrorAction Parallel step fail failed
+         -ErrorAction Parallel step fail failed
+         [14]{13}(1867)FlowEndNode End of Pipeline  [st=2]
+         -ErrorAction Parallel step fail failed
+         */
+
+        QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
+        WorkflowRun run = build.get();
+        j.assertBuildStatus(Result.FAILURE, run);
+        FlowExecution exec = run.getExecution();
+
+        // Overall flow
+        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
+                run, null, exec.getNode("2"), exec.getNode("14"), null));
+
+        // Failing branch
+        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
+                run, exec.getNode("4"), exec.getNode("7"), exec.getNode("10"), exec.getNode("13")));
+
+        // Passing branch
+        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, StatusAndTiming.computeChunkStatus(
+                run, exec.getNode("4"), exec.getNode("6"), exec.getNode("12"), exec.getNode("13")));
+
+        // Check that branch statuses match
+        List<BlockStartNode> parallelStarts = Arrays.asList((BlockStartNode) (exec.getNode("6")), (BlockStartNode) (exec.getNode("7")));
+        List<FlowNode> parallelEnds = Arrays.asList(exec.getNode("12"), exec.getNode("10"));
+        Map<String, StatusAndTiming.GenericStatus> branchStatuses = StatusAndTiming.computeBranchStatuses(run, exec.getNode("4"),
+                parallelStarts, parallelEnds,
+                exec.getNode("13"));
+
+        Assert.assertEquals(2, branchStatuses.size());
+        String[] branches = {"fail", "success"};
+        List<String> outputBranchList = new ArrayList<String>(branchStatuses.keySet());
+        Collections.sort(outputBranchList);
+        Assert.assertArrayEquals(branches, outputBranchList.toArray());
+        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, branchStatuses.get("fail"));
+        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, branchStatuses.get("success"));
+
+        // Verify that overall status returns as failure
+        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, StatusAndTiming.condenseStatus(branchStatuses.values()));
+
+        // Check timing computation for individual branches
+        long[] simulatedPauses = {50L, 5L}; // success, fail
+        Map<String, StatusAndTiming.TimingInfo> branchTimings = StatusAndTiming.computeParallelBranchTimings(
+            run, exec.getNode("4"), parallelStarts, parallelEnds, exec.getNode("13"), simulatedPauses
+        );
+        outputBranchList = new ArrayList<String>(branchTimings.keySet());
+        Collections.sort(outputBranchList);
+        Assert.assertArrayEquals(branches, outputBranchList.toArray());
+
+        // Passing branch time, 5 ms pause was a present above
+        StatusAndTiming.TimingInfo successTiming = branchTimings.get("success");
+        Assert.assertEquals(50L, successTiming.getPauseDurationMillis());
+        long successRunTime = doTiming(exec, 6, 13);
+        Assert.assertEquals(successRunTime, successTiming.getTotalDurationMillis());
+
+        // Failing branch time, 50 ms pause was a present above
+        StatusAndTiming.TimingInfo failTiming = branchTimings.get("fail");
+        long failRunTime = doTiming(exec, 7, 13);
+        Assert.assertEquals(Math.min(5L, failRunTime), failTiming.getPauseDurationMillis());
+        Assert.assertEquals(failRunTime, failTiming.getTotalDurationMillis());
+
+        // Check timing computation for overall result
+        StatusAndTiming.TimingInfo finalTiming = StatusAndTiming.computeOverallParallelTiming(
+                run, branchTimings, exec.getNode("4"), exec.getNode("13")
+        );
+        long totalBranchTiming = TimingAction.getStartTime(exec.getNode("13")) - TimingAction.getStartTime(exec.getNode("4"));
+        Assert.assertEquals(50L, finalTiming.getPauseDurationMillis());
+        Assert.assertEquals(totalBranchTiming, finalTiming.getTotalDurationMillis());
     }
 
     /*@Test
@@ -147,6 +298,8 @@ public class StatusAndTimingTest {
         FlowExecution exec = run.getExecution();
         printNodes(exec, startTime, true, true);
     }
+
+    // TODO test case to test NotExecutedNodeAction, in-progress normal with timing, in-progress parallels with timing
 
     @Test
     public void inputTest() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -366,7 +366,9 @@ public class StatusAndTimingTest {
         // In-progress branch uses current time
         time = timings.get("pause");
         Assert.assertEquals(0, time.getPauseDurationMillis());
-        Assert.assertEquals((double)(incompleteBranchTime), (double)(time.getTotalDurationMillis()), 2.0);
+
+        TimingInfo info = StatusAndTiming.computeOverallParallelTiming(run, timings, exec.getNode("4"), null);
+        Assert.assertEquals((double)(incompleteBranchTime),(double)(info.getTotalDurationMillis()), 2.0);
 
         SemaphoreStep.success("wait/1", null);
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -1,0 +1,193 @@
+package org.jenkinsci.plugins.workflow.pipelinegraphanalysis;
+
+import com.cloudbees.workflow.flownode.FlowNodeUtil;
+import hudson.model.Action;
+import hudson.model.Result;
+import hudson.model.queue.QueueTaskFuture;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.actions.TimingAction;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+import org.jenkinsci.plugins.workflow.graph.BlockEndNode;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * Created by svanoort on 7/19/16.
+ */
+public class StatusAndTimingTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    String pipelinePrefix = "pipelines/";
+
+    public String readResource(String location) throws IOException {
+        InputStream strm = getClass().getClassLoader().getResourceAsStream(location);
+        return IOUtils.toString(strm, "utf8");
+    }
+
+    FlowNode[] getNodes(FlowExecution exec, int[] ids) throws IOException {
+        FlowNode[] output = new FlowNode[ids.length];
+        for (int i=0; i < ids.length; i++) {
+            output[i] = exec.getNode(Integer.toString(ids[i]));
+        }
+        return output;
+    }
+
+    @Test
+    public void testBasicPass() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "Passes");
+        job.setDefinition(new CpsFlowDefinition("" +
+                "sleep 1 \n" +
+                "stage 'first' \n" +
+                "sleep 1 \n" +
+                "echo 'done' \n"));
+
+        /** Node dump follows, format:
+         [ID]{parent,ids}(millisSinceStartOfRun) flowClassName displayName [st=startId if a block node]
+         Action format:
+         - actionClassName actionDisplayName
+
+         [2]{}(N/A)FlowStartNode Start of Pipeline
+         [3]{2}(814)StepAtomNode Sleep
+         [4]{3}(1779)StepAtomNode first
+         -LogActionImpl Console Output
+         -LabelAction first
+         -StageActionImpl null
+         [5]{4}(1787)StepAtomNode Sleep
+         [6]{5}(2793)StepAtomNode Print Message
+         -LogActionImpl Console Output
+         [7]{6}(2796)FlowEndNode End of Pipeline  [st=2]
+         */
+        QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
+        j.assertBuildStatusSuccess(build);
+        WorkflowRun run = build.get();
+        long startTime = run.getStartTimeInMillis();
+
+        // Test status handling with the first few nodes
+        FlowNode[] n = getNodes(run.getExecution(), new int[]{2, 3, 4, 5, 6, 7});
+        StatusAndTiming.GenericStatus status = StatusAndTiming.computeChunkStatus(run, null, n[0], n[1], n[2]);
+        StatusAndTiming.TimingInfo timing = StatusAndTiming.computeChunkTiming(run, 0, null, n[0], n[1], n[2]);
+        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, status);
+        Assert.assertEquals(0, timing.getPauseDurationMillis());
+        Assert.assertEquals(TimingAction.getStartTime(n[2]) - run.getStartTimeInMillis(), timing.getTotalDurationMillis());
+
+        // Everything but start/end
+        status = StatusAndTiming.computeChunkStatus(run, n[0], n[1], n[4], n[5]);
+        timing = StatusAndTiming.computeChunkTiming(run, 2, n[0], n[1], n[4], n[5]);
+        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, status);
+        Assert.assertEquals(timing.getPauseDurationMillis(), 2);
+        Assert.assertEquals(TimingAction.getStartTime(n[5]) - TimingAction.getStartTime(n[1]), timing.getTotalDurationMillis());
+
+        // Whole flow
+        status = StatusAndTiming.computeChunkStatus(run, null, n[0], n[5], null);
+        timing = StatusAndTiming.computeChunkTiming(run, 0, null, n[0], n[5], null);
+        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, status);
+        Assert.assertEquals(0, timing.getPauseDurationMillis());
+        Assert.assertEquals(run.getDuration(), timing.getTotalDurationMillis());
+
+        // Custom unstable status
+        run.setResult(Result.UNSTABLE);
+        status = StatusAndTiming.computeChunkStatus(run, null, n[0], n[1], n[2]);
+        Assert.assertEquals(StatusAndTiming.GenericStatus.UNSTABLE, status);
+
+        // Failure should assume last chunk ran is where failure happened
+        run.setResult(Result.FAILURE);
+        status = StatusAndTiming.computeChunkStatus(run, null, n[0], n[1], n[2]);
+        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, status);
+
+        // First non-start node to final end node
+        status = StatusAndTiming.computeChunkStatus(run, n[0], n[1], n[5], null);
+        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILED, status);
+
+        // Whole flow except for end... since no errors here, failure must be at end!
+        status = StatusAndTiming.computeChunkStatus(run, n[0], n[1], n[4], n[5]);
+        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, status);
+    }
+
+    /** Tests the assignment of error nodes to flows */
+    @Test
+    public void testFail() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "Fails");
+        job.setDefinition(new CpsFlowDefinition("" +
+                "sleep 1 \n" +
+                "stage 'first' \n" +
+                "sleep 1 \n" +
+                "error('fails') \n"));
+        QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
+        j.assertBuildStatus(Result.FAILURE, build.get());
+        WorkflowRun run = build.get();
+        long startTime = run.getStartTimeInMillis();
+        FlowExecution exec = run.getExecution();
+        printNodes(exec, startTime, true, true);
+    }
+
+    /*@Test
+    public void testInProgress() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "Fails");
+        job.setDefinition(new CpsFlowDefinition("" +
+                "sleep 1 \n" +
+                "stage 'first' \n" +
+                "sleep 1 \n" +
+                "semaphore('fails') \n"));
+        QueueTaskFuture<WorkflowRun> build = job.scheduleBuild2(0);
+        j.assertBuildStatusSuccess(build);
+        WorkflowRun run = job.getLastBuild();
+        long startTime = run.getStartTimeInMillis();
+        FlowExecution exec = run.getExecution();
+        printNodes(exec, startTime, true, true);
+    }
+
+    @Test
+    public void inputTest() throws Exception {
+        String resource = readResource(pipelinePrefix + "pauseforinput.groovy");
+        System.out.println(resource);
+    }*/
+
+    /** Helper, prints flow graph in some detail */
+    public void printNodes(FlowExecution exec, long startTime, boolean showTiming, boolean showActions) {
+        List<FlowNode> sorted = FlowNodeUtil.getIdSortedExecutionNodeList(exec);
+        System.out.println("Node dump follows, format:");
+        System.out.println("[ID]{parent,ids}(millisSinceStartOfRun) flowClassName displayName [st=startId if a block node]");
+        System.out.println("Action format: ");
+        System.out.println("\t- actionClassName actionDisplayName");
+        System.out.println("------------------------------------------------------------------------------------------");
+        for (FlowNode node : sorted) {
+            StringBuilder formatted = new StringBuilder();
+            formatted.append('[').append(node.getId()).append(']');
+            formatted.append('{').append(StringUtils.join(node.getParentIds(), ',')).append('}');
+            if (showTiming) {
+                formatted.append('(');
+                if (node.getAction(TimingAction.class) != null) {
+                    formatted.append(TimingAction.getStartTime(node)-startTime);
+                } else {
+                    formatted.append("N/A");
+                }
+                formatted.append(')');
+            }
+            formatted.append(node.getClass().getSimpleName()).append(' ').append(node.getDisplayName());
+            if (node instanceof BlockEndNode) {
+                formatted.append("  [st=").append(((BlockEndNode)node).getStartNode().getId()).append(']');
+            }
+            if (showActions) {
+                for (Action a : node.getActions()) {
+                    if (!(a instanceof TimingAction)) {
+                        formatted.append("\n\t-").append(a.getClass().getSimpleName()).append(' ').append(a.getDisplayName());
+                    }
+                }
+            }
+            System.out.println(formatted);
+        }
+        System.out.println("------------------------------------------------------------------------------------------");
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/pipelinegraphanalysis/StatusAndTimingTest.java
@@ -91,43 +91,43 @@ public class StatusAndTimingTest {
 
         // Test status handling with the first few nodes
         FlowNode[] n = getNodes(run.getExecution(), new int[]{2, 3, 4, 5, 6, 7});
-        StatusAndTiming.GenericStatus status = StatusAndTiming.computeChunkStatus(run, null, n[0], n[1], n[2]);
-        StatusAndTiming.TimingInfo timing = StatusAndTiming.computeChunkTiming(run, 0, null, n[0], n[1], n[2]);
-        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, status);
+        GenericStatus status = StatusAndTiming.computeChunkStatus(run, null, n[0], n[1], n[2]);
+        TimingInfo timing = StatusAndTiming.computeChunkTiming(run, 0, null, n[0], n[1], n[2]);
+        Assert.assertEquals(GenericStatus.SUCCESS, status);
         Assert.assertEquals(0, timing.getPauseDurationMillis());
         Assert.assertEquals(TimingAction.getStartTime(n[2]) - run.getStartTimeInMillis(), timing.getTotalDurationMillis());
 
         // Everything but start/end
         status = StatusAndTiming.computeChunkStatus(run, n[0], n[1], n[4], n[5]);
         timing = StatusAndTiming.computeChunkTiming(run, 2, n[0], n[1], n[4], n[5]);
-        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, status);
+        Assert.assertEquals(GenericStatus.SUCCESS, status);
         Assert.assertEquals(timing.getPauseDurationMillis(), 2);
         Assert.assertEquals(TimingAction.getStartTime(n[5]) - TimingAction.getStartTime(n[1]), timing.getTotalDurationMillis());
 
         // Whole flow
         status = StatusAndTiming.computeChunkStatus(run, null, n[0], n[5], null);
         timing = StatusAndTiming.computeChunkTiming(run, 0, null, n[0], n[5], null);
-        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, status);
+        Assert.assertEquals(GenericStatus.SUCCESS, status);
         Assert.assertEquals(0, timing.getPauseDurationMillis());
         Assert.assertEquals(run.getDuration(), timing.getTotalDurationMillis());
 
         // Custom unstable status
         run.setResult(Result.UNSTABLE);
         status = StatusAndTiming.computeChunkStatus(run, null, n[0], n[1], n[2]);
-        Assert.assertEquals(StatusAndTiming.GenericStatus.UNSTABLE, status);
+        Assert.assertEquals(GenericStatus.UNSTABLE, status);
 
         // Failure should assume last chunk ran is where failure happened
         run.setResult(Result.FAILURE);
         status = StatusAndTiming.computeChunkStatus(run, null, n[0], n[1], n[2]);
-        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, status);
+        Assert.assertEquals(GenericStatus.SUCCESS, status);
 
         // First non-start node to final end node
         status = StatusAndTiming.computeChunkStatus(run, n[0], n[1], n[5], null);
-        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, status);
+        Assert.assertEquals(GenericStatus.FAILURE, status);
 
         // Whole flow except for end... since no errors here, failure must be at end!
         status = StatusAndTiming.computeChunkStatus(run, n[0], n[1], n[4], n[5]);
-        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, status);
+        Assert.assertEquals(GenericStatus.SUCCESS, status);
     }
 
     /** Tests the assignment of error nodes to flows */
@@ -163,19 +163,19 @@ public class StatusAndTimingTest {
         j.assertBuildStatus(Result.FAILURE, run);
 
         // Whole flow
-        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
+        Assert.assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
                 run, null, exec.getNode("2"), exec.getNode("7"), null));
 
         // Start through to failure point
-        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
+        Assert.assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
                 run, null, exec.getNode("2"), exec.getNode("6"), exec.getNode("7")));
 
         // All but first/last node
-        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
+        Assert.assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
                 run, exec.getNode("2"), exec.getNode("3"), exec.getNode("6"), exec.getNode("7")));
 
         // Before failure node
-        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, StatusAndTiming.computeChunkStatus(
+        Assert.assertEquals(GenericStatus.SUCCESS, StatusAndTiming.computeChunkStatus(
                 run, exec.getNode("2"), exec.getNode("3"), exec.getNode("5"), exec.getNode("6")));
     }
 
@@ -224,21 +224,21 @@ public class StatusAndTimingTest {
         FlowExecution exec = run.getExecution();
 
         // Overall flow
-        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
+        Assert.assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
                 run, null, exec.getNode("2"), exec.getNode("14"), null));
 
         // Failing branch
-        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
+        Assert.assertEquals(GenericStatus.FAILURE, StatusAndTiming.computeChunkStatus(
                 run, exec.getNode("4"), exec.getNode("7"), exec.getNode("10"), exec.getNode("13")));
 
         // Passing branch
-        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, StatusAndTiming.computeChunkStatus(
+        Assert.assertEquals(GenericStatus.SUCCESS, StatusAndTiming.computeChunkStatus(
                 run, exec.getNode("4"), exec.getNode("6"), exec.getNode("12"), exec.getNode("13")));
 
         // Check that branch statuses match
         List<BlockStartNode> parallelStarts = Arrays.asList((BlockStartNode) (exec.getNode("6")), (BlockStartNode) (exec.getNode("7")));
         List<FlowNode> parallelEnds = Arrays.asList(exec.getNode("12"), exec.getNode("10"));
-        Map<String, StatusAndTiming.GenericStatus> branchStatuses = StatusAndTiming.computeBranchStatuses(run, exec.getNode("4"),
+        Map<String, GenericStatus> branchStatuses = StatusAndTiming.computeBranchStatuses(run, exec.getNode("4"),
                 parallelStarts, parallelEnds,
                 exec.getNode("13"));
 
@@ -247,15 +247,15 @@ public class StatusAndTimingTest {
         List<String> outputBranchList = new ArrayList<String>(branchStatuses.keySet());
         Collections.sort(outputBranchList);
         Assert.assertArrayEquals(branches, outputBranchList.toArray());
-        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, branchStatuses.get("fail"));
-        Assert.assertEquals(StatusAndTiming.GenericStatus.SUCCESS, branchStatuses.get("success"));
+        Assert.assertEquals(GenericStatus.FAILURE, branchStatuses.get("fail"));
+        Assert.assertEquals(GenericStatus.SUCCESS, branchStatuses.get("success"));
 
         // Verify that overall status returns as failure
-        Assert.assertEquals(StatusAndTiming.GenericStatus.FAILURE, StatusAndTiming.condenseStatus(branchStatuses.values()));
+        Assert.assertEquals(GenericStatus.FAILURE, StatusAndTiming.condenseStatus(branchStatuses.values()));
 
         // Check timing computation for individual branches
         long[] simulatedPauses = {50L, 5L}; // success, fail
-        Map<String, StatusAndTiming.TimingInfo> branchTimings = StatusAndTiming.computeParallelBranchTimings(
+        Map<String, TimingInfo> branchTimings = StatusAndTiming.computeParallelBranchTimings(
             run, exec.getNode("4"), parallelStarts, parallelEnds, exec.getNode("13"), simulatedPauses
         );
         outputBranchList = new ArrayList<String>(branchTimings.keySet());
@@ -263,19 +263,19 @@ public class StatusAndTimingTest {
         Assert.assertArrayEquals(branches, outputBranchList.toArray());
 
         // Passing branch time, 5 ms pause was a present above
-        StatusAndTiming.TimingInfo successTiming = branchTimings.get("success");
+        TimingInfo successTiming = branchTimings.get("success");
         Assert.assertEquals(50L, successTiming.getPauseDurationMillis());
         long successRunTime = doTiming(exec, 6, 13);
         Assert.assertEquals(successRunTime, successTiming.getTotalDurationMillis());
 
         // Failing branch time, 50 ms pause was a present above
-        StatusAndTiming.TimingInfo failTiming = branchTimings.get("fail");
+        TimingInfo failTiming = branchTimings.get("fail");
         long failRunTime = doTiming(exec, 7, 13);
         Assert.assertEquals(Math.min(5L, failRunTime), failTiming.getPauseDurationMillis());
         Assert.assertEquals(failRunTime, failTiming.getTotalDurationMillis());
 
         // Check timing computation for overall result
-        StatusAndTiming.TimingInfo finalTiming = StatusAndTiming.computeOverallParallelTiming(
+        TimingInfo finalTiming = StatusAndTiming.computeOverallParallelTiming(
                 run, branchTimings, exec.getNode("4"), exec.getNode("13")
         );
         long totalBranchTiming = TimingAction.getStartTime(exec.getNode("13")) - TimingAction.getStartTime(exec.getNode("4"));
@@ -318,10 +318,10 @@ public class StatusAndTimingTest {
         e = (CpsFlowExecution)(run.getExecution());
 
         // Check that a pipeline paused on input gets the same status, and timing reflects in-progress node running through to current time
-        StatusAndTiming.GenericStatus status = StatusAndTiming.computeChunkStatus(run, null, e.getNode("2"), e.getNode("5"), null);
-        Assert.assertEquals(StatusAndTiming.GenericStatus.PAUSED_PENDING_INPUT, status);
+        GenericStatus status = StatusAndTiming.computeChunkStatus(run, null, e.getNode("2"), e.getNode("5"), null);
+        Assert.assertEquals(GenericStatus.PAUSED_PENDING_INPUT, status);
         long currentTime = System.currentTimeMillis();
-        StatusAndTiming.TimingInfo timing = StatusAndTiming.computeChunkTiming(run, 0L, null, e.getNode("2"), e.getNode("5"), null);
+        TimingInfo timing = StatusAndTiming.computeChunkTiming(run, 0L, null, e.getNode("2"), e.getNode("5"), null);
         long runTime = currentTime - run.getStartTimeInMillis();
         Assert.assertEquals((double) (runTime), (double) (timing.getTotalDurationMillis()), 10.0); // Approx b/c depends on when currentTime gathered
 


### PR DESCRIPTION
OSS-1190: tools for implementing the logic to assign a status & timing to arbitrary pieces of a pipeline flow.  Handles parallel cases and in-progress branches. 

**Components:**
- [x] Model enum describing different statuses for a FlowChunk (piece of a flow)
- [x] Model object to wrap up timing
- [x] API that takes a chunk of a flow with context (nodes before/after if existent) and computes a status (computeChunkStatus)
- [x] API that takes a chunk of a flow with context and computes timing for the chunk
- [x] API that will accept a set of parallel branches and assign each a status
- [x] API that will accept a set of parallel branches and assign each a timing
- [x] APIs to condense statuses and timings for parallel branches and report overall status/timing

**Cases tested:**
- [x] Status/timings within a basic flow
- [x] Statuses modified by changing results
- [x] Pause on input
- [x] Parallel branches with different statuses (one passing, one failing)
- [x] Parallel branches, with one in-progress
